### PR TITLE
Escaping validation messages used in javascript

### DIFF
--- a/src/Javascript/ValidatorHandler.php
+++ b/src/Javascript/ValidatorHandler.php
@@ -104,7 +104,7 @@ class ValidatorHandler
             list($jsAttribute, $jsRule, $jsParams) = $this->rules->getRule($attribute, $rule, $parameters, $rawRule);
             if ($this->isValidatable($jsRule, $includeRemote)) {
                 $jsRules[$jsAttribute][$jsRule][] = array($rule, $jsParams,
-                    $this->messages->getMessage($attribute, $rule, $parameters),
+                    e($this->messages->getMessage($attribute, $rule, $parameters)), // Escape text
                     $this->validator->isImplicit($rule),
                 );
             }

--- a/src/Remote/Validator.php
+++ b/src/Remote/Validator.php
@@ -97,7 +97,14 @@ class Validator
             return true;
         }
 
-        return $validator->messages()->get($attribute);
+        $messages = $validator->messages()->get($attribute);
+
+        // Escape all messages
+        foreach ($messages as $key => $value) {
+            $messages[$key] = e($value);
+        }
+
+        return $messages;
     }
 
     /**


### PR DESCRIPTION
As the javascript prints the messages as they are, it needs to be escaped to avoid the risk of XSS.